### PR TITLE
Added text for variable value

### DIFF
--- a/PCAxis.Query/Items/JsonTableResponse.cs
+++ b/PCAxis.Query/Items/JsonTableResponse.cs
@@ -72,6 +72,9 @@ namespace PCAxis.Query
         [JsonProperty("key")]
         public List<string> Key { get; set; }
 
+        [JsonProperty("text")]
+        public List<string> Text { get; set; }
+
         [JsonProperty("values")]
         public List<string> Values { get; set; }
 


### PR DESCRIPTION
Today, only the code for variable value is displayed in Json format. By adding text in json table response it is possible to display text for variable value